### PR TITLE
Make default lighting value 25

### DIFF
--- a/SynLT/Program.cs
+++ b/SynLT/Program.cs
@@ -9,7 +9,7 @@ using System.Drawing;
 namespace SynStandardLightingTemplate
 {
     public class Settings {
-        public byte Color = 5;
+        public byte Color = 25;
     }
     internal class Program
     {


### PR DESCRIPTION
Default lighting color has been updated from 5 to 25.

The mod had been updated to be a bit brighter to make it more accessible to a wider audience. This commit updates the lighting value used from 5 to 25 to bring it back inline with the mod's update.